### PR TITLE
You should not have a 'mod' key for an app that is not a server

### DIFF
--- a/src/dh_date.app.src
+++ b/src/dh_date.app.src
@@ -7,6 +7,5 @@
                   kernel,
                   stdlib
                  ]},
-  {mod, { dh_date, []}},
   {env, []}
  ]}.


### PR DESCRIPTION
The 'mod' part of an .app file is for running MODULE:start(Args)  when an app is started.

An app such as this has no start function, so should not have a 'mod' key.

(Another example of such an app is stdlib in OTP.)
